### PR TITLE
fix: stage fat JAR to dedicated input dir to prevent jpackage recursion

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -115,6 +115,27 @@
             <build>
                 <plugins>
                     <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-antrun-plugin</artifactId>
+                        <version>3.1.0</version>
+                        <executions>
+                            <execution>
+                                <id>stage-fat-jar</id>
+                                <phase>pre-integration-test</phase>
+                                <goals>
+                                    <goal>run</goal>
+                                </goals>
+                                <configuration>
+                                    <target>
+                                        <mkdir dir="${project.build.directory}/jpackage-input"/>
+                                        <copy file="${project.build.directory}/${project.artifactId}-${project.version}.jar"
+                                              todir="${project.build.directory}/jpackage-input"/>
+                                    </target>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
                         <groupId>org.codehaus.mojo</groupId>
                         <artifactId>exec-maven-plugin</artifactId>
                         <version>3.1.0</version>
@@ -131,7 +152,7 @@
                                         <argument>--type</argument>
                                         <argument>app-image</argument>
                                         <argument>--input</argument>
-                                        <argument>${project.build.directory}</argument>
+                                        <argument>${project.build.directory}/jpackage-input</argument>
                                         <argument>--main-jar</argument>
                                         <argument>${project.artifactId}-${project.version}.jar</argument>
                                         <argument>--name</argument>


### PR DESCRIPTION
jpackage --input target/ caused infinite recursion because --dest target/dist/ is a subdirectory of the input. Now copies only the fat JAR to target/jpackage-input/ before running jpackage.